### PR TITLE
fix(INC-5312): Omit image code if item image is nonexistent

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image ? item.image : '/placeholder.png'}
+        src={item.image ? item.image : "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -34,12 +34,12 @@ const ItemPreview = (props) => {
       className="card bg-dark border-light p-3"
       style={{ borderRadius: "20px" }}
     >
-      <img
+      {item.image && <img
         alt="item"
         src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
-      />
+      />}
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">
           <h3 className="card-title">{item.title}</h3>

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -34,12 +34,12 @@ const ItemPreview = (props) => {
       className="card bg-dark border-light p-3"
       style={{ borderRadius: "20px" }}
     >
-      {<img
+      <img
         alt="item"
-        src={item.image ? item.image : '/placeholder.png' }
+        src={item.image ? item.image : '/placeholder.png'}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
-      />}
+      />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">
           <h3 className="card-title">{item.title}</h3>

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -34,9 +34,9 @@ const ItemPreview = (props) => {
       className="card bg-dark border-light p-3"
       style={{ borderRadius: "20px" }}
     >
-      {item.image && <img
+      {<img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : '/placeholder.png' }
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />}


### PR DESCRIPTION
# Description
**Observed Behavior:** Item images when not added by the user show up as broken files.
**Desired Behavior:** If item images are not specified by the user, show a placeholder image.

# Screenshot
![image](https://user-images.githubusercontent.com/1065090/181145914-6df93f03-3ab2-46af-82bd-928265ae7cd1.png)
