### PR TITLE
fix(INC-5312): Show placeholder image  if item image is nonexistent

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description
**Observed Behavior:** Item images when not added by the user show up as broken files.
**Desired Behavior:** If item images are not specified by the user, show a placeholder image.

# Screenshot
![image](https://user-images.githubusercontent.com/1065090/181145914-6df93f03-3ab2-46af-82bd-928265ae7cd1.png)
